### PR TITLE
Fix import scale issue for gerbers using imperial units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ yarn-debug.log*
 yarn-error.log*
 
 .tpm/
+.tmp/
 
 # Developer tools' files
 .lite_workspace.lua

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photonic-etcher",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Generate exposure masks for Anycubic printers from PCB Gerbers",
   "homepage": ".",
   "bugs": {

--- a/src/renderer/render-to-photon.ts
+++ b/src/renderer/render-to-photon.ts
@@ -36,8 +36,21 @@ const {CanvasToImage} = require("./canvas_to_img");
 
     for (const layer of layers) {
         const svgXMLObj = parser.parse(layer.svg);
-        const board_width_mm = parseFloat(svgXMLObj.svg['@_width'].replace("mm", ""));
-        const board_height_mm = parseFloat(svgXMLObj.svg['@_height'].replace("mm", ""));
+        var board_width_mm;
+        var board_height_mm;
+        console.log(svgXMLObj.svg['@_height']);
+        if(svgXMLObj.svg['@_width'].endsWith('in'))
+        {
+            board_width_mm = parseFloat(svgXMLObj.svg['@_width'].replace("in", ""))*25.4;
+            board_height_mm = parseFloat(svgXMLObj.svg['@_height'].replace("in", ""))*25.4;
+        }
+        else
+        {
+            board_width_mm = parseFloat(svgXMLObj.svg['@_width'].replace("mm", ""));
+            board_height_mm = parseFloat(svgXMLObj.svg['@_height'].replace("mm", ""));
+        }
+        console.log(board_height_mm);
+
         const viewbox = svgXMLObj.svg['@_viewBox'].split(' ').map((str) => parseInt(str));
         const exposureTime = options.exposureTimes[layer.id];
         let outputFileName = ""

--- a/src/renderer/render-to-photon.ts
+++ b/src/renderer/render-to-photon.ts
@@ -38,7 +38,6 @@ const {CanvasToImage} = require("./canvas_to_img");
         const svgXMLObj = parser.parse(layer.svg);
         var board_width_mm;
         var board_height_mm;
-        console.log(svgXMLObj.svg['@_height']);
         if(svgXMLObj.svg['@_width'].endsWith('in'))
         {
             board_width_mm = parseFloat(svgXMLObj.svg['@_width'].replace("in", ""))*25.4;
@@ -49,7 +48,6 @@ const {CanvasToImage} = require("./canvas_to_img");
             board_width_mm = parseFloat(svgXMLObj.svg['@_width'].replace("mm", ""));
             board_height_mm = parseFloat(svgXMLObj.svg['@_height'].replace("mm", ""));
         }
-        console.log(board_height_mm);
 
         const viewbox = svgXMLObj.svg['@_viewBox'].split(' ').map((str) => parseInt(str));
         const exposureTime = options.exposureTimes[layer.id];


### PR DESCRIPTION
Eagle uses inch for it's units in the gerbers.

gerber-to-svg retains the inch units.

This patch checks if the width value in the SVG ends with "in" then multiplies the sizes with 25.4 to get to mm.