### PR TITLE
add Anycubic photon mono 4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Photonic Etcher is a browser-based tool for converting gerber files into "printa
  - AnyCubic Photon Mono X (.pwmx)
  - AnyCubic Photon & Photon S (.pws)
  - AnyCubic Photon X (.pwx)
+ - AnyCubic Photon Mono 4 (.pm4n)
 
 If you're interested in support for additional formats, [open an issue](https://github.com/Andrew-Dickinson/photonic-etcher/issues/new), and I'll look into it.
 

--- a/src/ui/export_dialog.tsx
+++ b/src/ui/export_dialog.tsx
@@ -13,7 +13,7 @@ export interface PrinterModel {
     previewResolution: [number, number],
     rotate180: boolean,
     encoding: "RLE" | "RLE4",
-    fileFormat: "dlp" | "pm3" | "pm3m" | "pmsq" | "pw0" | "pwma" | "pwmb" | "pwmo" | "pwms" | "pwmx" | "pws" | "photon" | "pwx"
+    fileFormat: "dlp" | "pm3" | "pm3m" | "pmsq" | "pw0" | "pwma" | "pwmb" | "pwmo" | "pwms" | "pwmx" | "pws" | "photon" | "pwx" | "pm4n"
 }
 const printerModels: { [key: string]: PrinterModel } = {
     'AnyCubic Photon Ultra (.dlp)': {
@@ -127,6 +127,15 @@ const printerModels: { [key: string]: PrinterModel } = {
         "rotate180": true,
         "encoding": "RLE4",
         "fileFormat": "pwx"
+    },
+    'AnyCubic Photon Mono 4 (.pm4n)': {
+        "fileVersion": [1, 4],
+        "xyRes": 0.017,
+        "resolution": [9024, 5120],
+        "previewResolution": [224, 168],
+        "rotate180": false,
+        "encoding": "RLE4",
+        "fileFormat": "pm4n"
     },
 }
 


### PR DESCRIPTION
just added Anycubic Photon Mono 4 (not ultra) support

i believe atm Mono 4 is one of the most affordable printers offering a ridiculously high '10K' resolution and 17um pixel pitch, making it an ideal choice for an 'off-label' PCB etching job

constants (screen resolution, file format etc) taken from [uvtools](https://github.com/sn4k3/UVtools/)
tested on my own printer